### PR TITLE
Add a spawn egg item for the Otter

### DIFF
--- a/src/main/java/net/livzmc/ottah/OttahMod.java
+++ b/src/main/java/net/livzmc/ottah/OttahMod.java
@@ -1,6 +1,8 @@
 package net.livzmc.ottah;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.livzmc.ottah.entity.passive.OtterEntity;
@@ -9,6 +11,9 @@ import net.livzmc.ottah.sound.OtterSounds;
 import net.minecraft.entity.EntityDimensions;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroups;
+import net.minecraft.item.SpawnEggItem;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
@@ -23,10 +28,18 @@ public class OttahMod implements ModInitializer {
                     .build()
     );
 
+    // create an instance of SpawnEggItem
+    public static final Item OTTER_SPAWN_EGG = new SpawnEggItem(Otter,0x866a67, 0xb3a28e, new FabricItemSettings());
+
     @Override
     public void onInitialize() {
         FabricDefaultAttributeRegistry.register(Otter, OtterEntity.createOtterAttributes());
         new OtterSounds();
         OtterSpawn.init();
+
+        // register the item OTTER_SPAWN_EGG
+        Registry.register(Registries.ITEM, new Identifier("ottah","otter_spawn_egg"),OTTER_SPAWN_EGG);
+        // add the item OTTER_SPAWN_EGG to the vanilla "Spawn Eggs" creative tab
+        ItemGroupEvents.modifyEntriesEvent(ItemGroups.SPAWN_EGGS).register(entries -> entries.add(OTTER_SPAWN_EGG));
     }
 }

--- a/src/main/resources/assets/ottah/lang/en_us.json
+++ b/src/main/resources/assets/ottah/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "entity.ottah.otter": "Otter",
+  "item.ottah.otter_spawn_egg": "Otter Spawn Egg"
+}

--- a/src/main/resources/assets/ottah/models/item/otter_spawn_egg.json
+++ b/src/main/resources/assets/ottah/models/item/otter_spawn_egg.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:item/template_spawn_egg"
+}


### PR DESCRIPTION
This pull request adds a spawn egg for the Otter mob. This spawn egg can be found in the vanilla "Spawn Eggs" creative tab and is used like any other spawn egg item.